### PR TITLE
Add a simple line of redis URL in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 API_PORT=8080
 DATABASE_URL="postgresql://postgres:postgres@localhost:5432/postgres"
+REDIS_URL="redis://localhost:6379/0"


### PR DESCRIPTION
I just add a line of redis url, because i clone this project but found an error to run.

With this small fix, the project will run without problems when following the Makefile.